### PR TITLE
Fix SonarCloud CI configuration

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -2,13 +2,16 @@ name: SonarCloud
 
 on:
   workflow_run:
-    workflows: ["Tests (PHP) with MySQL"]
-    types: [completed]
+    workflows:
+      - Tests (PHP) with MySQL
+    types:
+      - completed
 
 jobs:
   sonarqube:
     name: SonarQube
     runs-on: ubuntu-latest
+
     permissions:
       actions: read
       contents: read
@@ -17,6 +20,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          repository: ${{ github.event.workflow_run.head_repository.full_name }}
+          ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
 
       - name: Download test artifacts
@@ -33,7 +38,3 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        with:
-          args: >
-            -Dsonar.organization=${{ secrets.SONAR_ORGANIZATION }}
-            -Dsonar.projectKey=${{ secrets.SONAR_PROJECT_KEY }}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,8 @@
+sonar.projectKey=catch-oss_ss-twig-elemental
+sonar.organization=catch-design
+sonar.sources=src
+sonar.tests=tests
+sonar.sourceEncoding=UTF-8
+sonar.php.coverage.reportPaths=coverage/php/coverage.xml
+sonar.php.tests.reportPath=coverage/php/junit.xml
+sonar.exclusions=vendor/**,tests/**


### PR DESCRIPTION
## Summary
- Replace secret-based SonarCloud args with `sonar-project.properties` file for project key and organization
- Add `repository` and `ref` to checkout step so SonarCloud correctly analyses PR branches
- Remove `args` block from SonarQube Scan step (configuration now in properties file)

## Test plan
- [ ] Verify SonarCloud workflow triggers after a test run on this branch
- [ ] Confirm SonarCloud scan completes without "project not found" errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)