### PR TITLE
Update SonarCloud workflow and add config

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -6,9 +6,27 @@ on:
     types: [completed]
 
 jobs:
-  sonarqube:
-    name: SonarQube
+  sonarcloud:
+    name: SonarCloud
     runs-on: ubuntu-latest
+
+    env:
+      SONAR_PROJECT_KEY: catch-design_https-github-com-catch-oss-ss-twig-elemental
+
+    outputs:
+      alert_status: ${{ steps.sonarqube-report.outputs.alert_status }}
+      bugs: ${{ steps.sonarqube-report.outputs.bugs }}
+      code_smells: ${{ steps.sonarqube-report.outputs.code_smells }}
+      coverage: ${{ steps.sonarqube-report.outputs.coverage }}
+      duplicated_lines_density: ${{ steps.sonarqube-report.outputs.duplicated_lines_density }}
+      ncloc: ${{ steps.sonarqube-report.outputs.ncloc }}
+      reliability_rating: ${{ steps.sonarqube-report.outputs.reliability_rating }}
+      security_rating: ${{ steps.sonarqube-report.outputs.security_rating }}
+      sqale_index: ${{ steps.sonarqube-report.outputs.sqale_index }}
+      sqale_rating: ${{ steps.sonarqube-report.outputs.sqale_rating }}
+      vulnerabilities: ${{ steps.sonarqube-report.outputs.vulnerabilities }}
+      git_ref: ${{ steps.sonarqube-report.outputs.git_ref }}
+
     permissions:
       actions: read
       contents: read
@@ -17,6 +35,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          repository: ${{ github.event.workflow_run.head_repository.full_name }}
+          ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
 
       - name: Download test artifacts
@@ -28,12 +48,83 @@ jobs:
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: SonarQube Scan
+      - name: SonarCloud Scan
+        id: sonarqube-scan
         uses: SonarSource/sonarqube-scan-action@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
+      - name: Resolve SonarCloud ref
+        id: sonar-ref
+        env:
+          PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+        run: |
+          if [ "$PR_NUMBER" != "" ]; then
+            echo "ref=pullRequest=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+          else
+            ENCODED_REF=$(printf '%s' "$HEAD_BRANCH" | jq -sRr @uri)
+            echo "ref=branch=$ENCODED_REF" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Fail job if Quality Gate fails
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_REF: ${{ steps.sonar-ref.outputs.ref }}
+        run: |
+          if ! RESPONSE=$(curl --fail --silent \
+            -H "Authorization: Bearer $SONAR_TOKEN" \
+            "https://sonarcloud.io/api/measures/component?metricKeys=alert_status&component=$SONAR_PROJECT_KEY&$SONAR_REF"); then
+            echo "Failed to fetch quality gate status from SonarCloud API"
+            exit 1
+          fi
+
+          STATUS=$(echo "$RESPONSE" | jq -r '.component.measures[0].value // "ERROR"')
+          echo "Quality Gate: ${STATUS}"
+          [ "$STATUS" = "OK" ] || { echo "Quality Gate failed with status: $STATUS"; exit 1; }
+
+      - name: Output SonarCloud metrics
+        id: sonarqube-report
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_REF: ${{ steps.sonar-ref.outputs.ref }}
+        run: |
+          REF="$SONAR_REF"
+
+          if ! DATA=$(curl --fail --silent --request GET \
+            --url "https://sonarcloud.io/api/measures/component?metricKeys=alert_status%2Cbugs%2Ccode_smells%2Ccoverage%2Cduplicated_lines_density%2Cncloc%2Creliability_rating%2Csecurity_rating%2Csqale_index%2Csqale_rating%2Cvulnerabilities&component=$SONAR_PROJECT_KEY&$REF" \
+            --header "Authorization: Bearer $SONAR_TOKEN"); then
+            echo "Failed to fetch metrics from SonarCloud API"
+            exit 1
+          fi
+
+          for metric in alert_status bugs code_smells coverage duplicated_lines_density ncloc reliability_rating security_rating sqale_index sqale_rating vulnerabilities; do
+            value=$(echo "$DATA" | jq -r --arg m "$metric" '.component.measures[] | select(.metric == $m) | .value')
+            echo "${metric}=${value}" >> "$GITHUB_OUTPUT"
+          done
+          echo "git_ref=${REF}" >> "$GITHUB_OUTPUT"
+
+      - name: Comment PR
+        uses: thollander/actions-comment-pull-request@v3
+        if: github.event.workflow_run.pull_requests[0].number != ''
         with:
-          args: >
-            -Dsonar.organization=${{ secrets.SONAR_ORGANIZATION }}
-            -Dsonar.projectKey=${{ secrets.SONAR_PROJECT_KEY }}
+          pr-number: ${{ github.event.workflow_run.pull_requests[0].number }}
+          message: |
+            ## SonarCloud Analysis Results
+            ### Quality Gate Status: ${{ steps.sonarqube-report.outputs.alert_status }}
+            ### Metrics
+            - **Bugs**: ${{ steps.sonarqube-report.outputs.bugs }}
+            - **Code Smells**: ${{ steps.sonarqube-report.outputs.code_smells }}
+            - **Coverage**: ${{ steps.sonarqube-report.outputs.coverage }}
+            - **Duplicated Lines Density**: ${{ steps.sonarqube-report.outputs.duplicated_lines_density }}
+            - **Lines of Code (ncloc)**: ${{ steps.sonarqube-report.outputs.ncloc }}
+            - **Reliability Rating**: ${{ steps.sonarqube-report.outputs.reliability_rating }}
+            - **Security Rating**: ${{ steps.sonarqube-report.outputs.security_rating }}
+            - **Technical Debt (sqale index)**: ${{ steps.sonarqube-report.outputs.sqale_index }}
+            - **Maintainability Rating**: ${{ steps.sonarqube-report.outputs.sqale_rating }}
+            - **Vulnerabilities**: ${{ steps.sonarqube-report.outputs.vulnerabilities }}
+            ### More details
+            - [SonarCloud dashboard](https://sonarcloud.io/dashboard?id=catch-design_https-github-com-catch-oss-ss-twig-elemental&${{ steps.sonarqube-report.outputs.git_ref }})
+            - [View the full report](https://sonarcloud.io/project/issues?id=catch-design_https-github-com-catch-oss-ss-twig-elemental&${{ steps.sonarqube-report.outputs.git_ref }}&resolved=false)
+            - [View the Quality Gate](https://sonarcloud.io/summary/new_code?id=catch-design_https-github-com-catch-oss-ss-twig-elemental&${{ steps.sonarqube-report.outputs.git_ref }})

--- a/README.md
+++ b/README.md
@@ -1,5 +1,20 @@
 # Twig Elemental Blocks
 
+<!-- PROJECT SHIELDS -->
+[![SonarCloud](https://github.com/catch-oss/ss-twig-elemental/actions/workflows/sonar.yml/badge.svg)](https://github.com/catch-oss/ss-twig-elemental/actions/workflows/sonar.yml)
+[![Test](https://github.com/catch-oss/ss-twig-elemental/actions/workflows/test.yml/badge.svg)](https://github.com/catch-oss/ss-twig-elemental/actions/workflows/test.yml)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=catch-design_https-github-com-catch-oss-ss-twig-elemental&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=catch-design_https-github-com-catch-oss-ss-twig-elemental)
+[![Bugs](https://sonarcloud.io/api/project_badges/measure?project=catch-design_https-github-com-catch-oss-ss-twig-elemental&metric=bugs)](https://sonarcloud.io/component_measures?id=catch-design_https-github-com-catch-oss-ss-twig-elemental)
+[![Code Smells](https://sonarcloud.io/api/project_badges/measure?project=catch-design_https-github-com-catch-oss-ss-twig-elemental&metric=code_smells)](https://sonarcloud.io/component_measures?id=catch-design_https-github-com-catch-oss-ss-twig-elemental)
+[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=catch-design_https-github-com-catch-oss-ss-twig-elemental&metric=coverage)](https://sonarcloud.io/component_measures?id=catch-design_https-github-com-catch-oss-ss-twig-elemental)
+[![Duplicated Lines Density](https://sonarcloud.io/api/project_badges/measure?project=catch-design_https-github-com-catch-oss-ss-twig-elemental&metric=duplicated_lines_density)](https://sonarcloud.io/component_measures?id=catch-design_https-github-com-catch-oss-ss-twig-elemental)
+[![Lines of Code](https://sonarcloud.io/api/project_badges/measure?project=catch-design_https-github-com-catch-oss-ss-twig-elemental&metric=ncloc)](https://sonarcloud.io/component_measures?id=catch-design_https-github-com-catch-oss-ss-twig-elemental)
+[![Reliability Rating](https://sonarcloud.io/api/project_badges/measure?project=catch-design_https-github-com-catch-oss-ss-twig-elemental&metric=reliability_rating)](https://sonarcloud.io/component_measures?id=catch-design_https-github-com-catch-oss-ss-twig-elemental)
+[![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=catch-design_https-github-com-catch-oss-ss-twig-elemental&metric=security_rating)](https://sonarcloud.io/component_measures?id=catch-design_https-github-com-catch-oss-ss-twig-elemental)
+[![Technical Debt](https://sonarcloud.io/api/project_badges/measure?project=catch-design_https-github-com-catch-oss-ss-twig-elemental&metric=sqale_index)](https://sonarcloud.io/component_measures?id=catch-design_https-github-com-catch-oss-ss-twig-elemental)
+[![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=catch-design_https-github-com-catch-oss-ss-twig-elemental&metric=sqale_rating)](https://sonarcloud.io/component_measures?id=catch-design_https-github-com-catch-oss-ss-twig-elemental)
+[![Vulnerabilities](https://sonarcloud.io/api/project_badges/measure?project=catch-design_https-github-com-catch-oss-ss-twig-elemental&metric=vulnerabilities)](https://sonarcloud.io/component_measures?id=catch-design_https-github-com-catch-oss-ss-twig-elemental)
+
 This extension allows Twig templates to be used for Elemental Blocks
 
 ## Usage

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,14 @@
+sonar.projectKey=catch-design_https-github-com-catch-oss-ss-twig-elemental
+sonar.organization=catch-design
+
+# Source and test paths
+sonar.sources=src
+sonar.tests=tests
+sonar.sourceEncoding=UTF-8
+
+# PHP coverage - these paths match the test.yml output
+sonar.php.coverage.reportPaths=coverage/php/coverage.xml
+sonar.php.tests.reportPath=coverage/php/junit.xml
+
+# Exclusions
+sonar.exclusions=vendor/**,tests/**

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,7 +3,6 @@ sonar.organization=catch-design
 
 # Source and test paths
 sonar.sources=src
-sonar.tests=tests
 sonar.sourceEncoding=UTF-8
 
 # PHP coverage - these paths match the test.yml output
@@ -11,4 +10,4 @@ sonar.php.coverage.reportPaths=coverage/php/coverage.xml
 sonar.php.tests.reportPath=coverage/php/junit.xml
 
 # Exclusions
-sonar.exclusions=vendor/**,tests/**
+sonar.exclusions=vendor/**


### PR DESCRIPTION
## Summary

Updates CI workflows for the SS6 migration:

- **sonar.yml**: Rewritten with proper `workflow_run` checkout, DRY project key via job-level `env`, shared ref resolution step, `curl --fail` for API calls, metric extraction loop, and PR commenting
- **sonar-project.properties**: Project key, org, source/test paths, coverage report paths
- **README.md**: CI and SonarCloud badges

### Secrets Required

Ensure these secrets are configured (org-level or repo-level):
- `ANTHROPIC_API_KEY` - for Claude PR review
- `SONAR_TOKEN` - for SonarCloud analysis

Note: `sonar.organization` and `sonar.projectKey` are read from `sonar-project.properties` — they do NOT need to be set as secrets.

---

Generated by SS6 Migration Toolkit